### PR TITLE
Added `exclude-bin` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added the `exclude-bin` option to exclude any package that defines a binary (default `true`).
 
 ## [1.1.1] - 2022-02-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added the `exclude-bin` option to exclude any package that defines a binary (default `true`).
+- Added the `exclude-bin` option to exclude any package that defines a binary (default `false`).
 
 ## [1.1.1] - 2022-02-11
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can configure the plugin using the `extra.global-installer` key in `composer
 
 - `path`: Path to global vendor directory. (default: `/usr/local/lib/composer/vendor/`)
 - `exclude`: Array of excluded package names (including vendor prefix), these packages will be installed locally.
-- `exlude-bin`: Whether to exclude any packages that hold a binary. (default: `true`)
+- `exclude-bin`: Whether to exclude any packages that hold a binary. (default: `true`)
 - `stabilities`: Array of supported branch stabilities. (default: `["alpha", "beta", "RC", "stable"]`)
 
 Example:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can configure the plugin using the `extra.global-installer` key in `composer
 
 - `path`: Path to global vendor directory. (default: `/usr/local/lib/composer/vendor/`)
 - `exclude`: Array of excluded package names (including vendor prefix), these packages will be installed locally.
+- `exlude-bin`: Whether to exclude any packages that hold a binary. (default: `true`)
 - `stabilities`: Array of supported branch stabilities. (default: `["alpha", "beta", "RC", "stable"]`)
 
 Example:
@@ -36,7 +37,7 @@ Example:
 				"vendor/package",
 				"vendor/package-two"
 			],
-			"stablilities": ["stable"]
+			"stabilities": ["stable"]
 		}
 	}
 }

--- a/res/schema.json
+++ b/res/schema.json
@@ -21,7 +21,7 @@
     "exclude-bin": {
       "type": "boolean",
       "description": "Excludes packages that define a binary file.",
-      "default": true
+      "default": false
     },
     "stabilities": {
       "type": "array",

--- a/res/schema.json
+++ b/res/schema.json
@@ -18,6 +18,11 @@
         "pattern": "^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]?|-{0,2})[a-z0-9]+)*$"
       }
     },
+    "exclude-bin": {
+      "type": "boolean",
+      "description": "Excludes packages that define a binary file.",
+      "default": true
+    },
     "stabilities": {
       "type": "array",
       "description": "Array of supported branch stabilities.",

--- a/src/GlobalInstaller.php
+++ b/src/GlobalInstaller.php
@@ -210,7 +210,7 @@ class GlobalInstaller extends LibraryInstaller
             return false;
         }
 
-        if (($this->options->{'exclude-bin'} ?? true) && $package->getBinaries()) {
+        if (($this->options->{'exclude-bin'} ?? false) && $package->getBinaries()) {
             return false;
         }
 

--- a/src/GlobalInstaller.php
+++ b/src/GlobalInstaller.php
@@ -210,6 +210,10 @@ class GlobalInstaller extends LibraryInstaller
             return false;
         }
 
+        if (($this->options->{'exclude-bin'} ?? true) && $package->getBinaries()) {
+            return false;
+        }
+
         return !in_array($package->getPrettyName(), $this->options->exclude ?? [], true);
     }
 }

--- a/tests/GlobalInstallerTest.php
+++ b/tests/GlobalInstallerTest.php
@@ -140,7 +140,7 @@ class GlobalInstallerTest extends TestCase
      * @param bool $has_binary Whether the package has a binary.
      * @param bool $expects_global_dir Whether the result should return the global vendor dir.
      * @testWith [true, true, false]
-     *           [null, true, false]
+     *           [null, true, true]
      *           [false, true, true]
      *           [false, false, true]
      */

--- a/tests/GlobalInstallerTest.php
+++ b/tests/GlobalInstallerTest.php
@@ -44,7 +44,7 @@ class GlobalInstallerTest extends TestCase
         $config->merge([
             'config' => [
                 'vendor-dir' => '/tmp/composer',
-            ]
+            ],
         ]);
         $this->composer->setConfig($config);
         $this->installer = new GlobalInstaller(
@@ -55,6 +55,7 @@ class GlobalInstallerTest extends TestCase
             (object)[
                 'stabilities' => ['stable'],
                 'exclude' => ['is-excluded'],
+                'exclude-bin' => true,
             ],
         );
     }
@@ -130,5 +131,50 @@ class GlobalInstallerTest extends TestCase
         ]);
 
         self::assertSame(realpath('/tmp/composer') . '/is-excluded', $this->installer->getInstallPath($package));
+    }
+
+    /**
+     * Test case for {@see GlobalInstaller::getInstallPath()} with a package that has binaries.
+     * @since $ver$
+     * @param bool $exclude_bin Whether the installer should exclude packages with a binary.
+     * @param bool $has_binary Whether the package has a binary.
+     * @param bool $expects_global_dir Whether the result should return the global vendor dir.
+     * @testWith [true, true, false]
+     *           [null, true, false]
+     *           [false, true, true]
+     *           [false, false, true]
+     */
+    public function testGetInstallPathWithExcludedBinaries(
+        ?bool $exclude_bin,
+        bool $has_binary,
+        bool $expects_global_dir
+    ): void {
+        $installer = new GlobalInstaller(
+            new NullIO(),
+            $this->composer,
+            '/project-dir',
+            '/global-dir',
+            (object)[
+                'stabilities' => ['stable'],
+                'exclude-bin' => $exclude_bin,
+            ],
+        );
+        $config = [
+            'getPrettyName' => 'has-binaries',
+            'getPrettyVersion' => '1.0.1',
+            'getStability' => 'stable',
+        ];
+
+        if ($has_binary) {
+            $config['getBinaries'] = ['bin/some-binary'];
+        }
+
+        $package = $this->createConfiguredMock(PackageInterface::class, $config);
+
+        $expected_path = $expects_global_dir
+            ? '/global-dir/has-binaries/1.0.1'
+            : realpath('/tmp/composer') . '/has-binaries';
+
+        self::assertSame($expected_path, $installer->getInstallPath($package));
     }
 }


### PR DESCRIPTION
This PR resolves #7 . 

This PR add's a `exclude-bin` configuration option that will exclude any packages that define a binary. 

**Note!**  
~~The configuration setting is set to `true` by default. This might be a "breaking change" but this will most likely solve most problem people have on update. The chances of someone want this to be `false` are slim to none;  as binaries often don't work when called from the global-vendor-dir.~~

We've changed it to `false` by default.